### PR TITLE
Ctrl+Shift+Z shortcut on Mac OS X now uses Ctrl

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,8 @@
   	"commands": {
     		"sprint-read-shortcut": {
       			"suggested_key": {
-        			"default": "Ctrl+Shift+Z"
+        			"default": "Ctrl+Shift+Z",
+        			"mac": "MacCtrl+Shift+Z"
       			},
       		"description": "Sprint read selected text"
       		}


### PR DESCRIPTION
Previously, it used Cmd+Shift+Z, overriding Redo on Mac OS X. 

Relates to this issue: https://github.com/anthonynosek/sprint-reader-chrome/issues/3

Help from: https://code.google.com/p/chromium/codesearch#chromium/src/chrome/common/extensions/docs/examples/api/commands/manifest.json
https://developer.chrome.com/extensions/commands