### PR TITLE
FIX: https://github.com/anthonynosek/sprint-reader-chrome/issues/15

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
   	"name": "Sprint Reader - Speed Reading Extension",
   	"description": "Speed reading made easy, train yourself to read 1800+ words per minute. Rapid serial visual presentation (RSVP) at its best!",
   	"version": "2.2",
+    "options_page": "src/welcome.html",
   	"content_scripts": [{
       		"matches": ["http://*/*", "https://*/*"],
 		"css": ["src/css/stylepage.css"],


### PR DESCRIPTION
Ideally, the options page would allow changing the keymap, but for now at least provide the info to the user by re-using the welcome.html page.